### PR TITLE
Fix constructing i18n directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
   treeForPublic: function(tree) {
     var outputPath = (this.app.options['ember-bundle-i18n'] && this.app.options['ember-bundle-i18n'].outputPath) || 'assets/i18n';
 
-    return new I18nAssetBuilder(this.app.trees.app + '/i18n', {
+    return new I18nAssetBuilder(this.project.root + '/app/i18n', {
       outputPath: outputPath
     });
   }


### PR DESCRIPTION
`this.app.trees.app` can be a string pointing to the app directory or a
broccoli node. In cases where it is a broccoli node, performing a string
concat will not give the intended result. `this.project.root` should
always be a string, as that is what it is supposed to be doing.
