### PR TITLE
Merge translations in default locale into other locales

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
+    'ember-bundle-i18n': {
+      inputPath: 'tests/dummy/app/i18n'
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+
 var I18nAssetBuilder = require('./lib/i18n-asset-builder');
+var I18nAssetMerger = require('./lib/i18n-asset-merger');
 
 module.exports = {
   name: 'ember-bundle-i18n',
@@ -9,10 +12,19 @@ module.exports = {
   isLocalizationFramework: true,
 
   treeForPublic: function(tree) {
-    var outputPath = (this.app.options['ember-bundle-i18n'] && this.app.options['ember-bundle-i18n'].outputPath) || 'assets/i18n';
+    var options = this.app.options['ember-bundle-i18n'] || {};
+    var outputPath = options.outputPath || 'assets/i18n';
+    var inputPath = options.inputPath || 'app/i18n';
+    inputPath = path.join(this.project.root, inputPath);
 
-    return new I18nAssetBuilder(this.app.trees.app + '/i18n', {
-      outputPath: outputPath
+    var inputTree = new I18nAssetMerger(inputPath, {
+      outputPath: outputPath,
+      annotation: 'ember-bundle-i18n: merge properties'
+    });
+
+    return new I18nAssetBuilder(inputTree, {
+      outputPath: outputPath,
+      destDir: 'ember-bundle-i18n: parse properties'
     });
   }
 };

--- a/lib/i18n-asset-builder.js
+++ b/lib/i18n-asset-builder.js
@@ -1,33 +1,35 @@
-var Filter = require('broccoli-filter');
+var Plugin = require('broccoli-plugin');
+var fs = require('fs');
 var PropertiesParser = require('properties-parser');
-var I18nAssetMerger = require('./i18n-asset-merger');
+var mkrip = require('mkdirp');
+var path = require('path');
+var merge = require('lodash.merge');
 
-I18nAssetBuilder.prototype = Object.create(Filter.prototype);
-I18nAssetBuilder.prototype.constructor = I18nAssetBuilder;
+I18NAssetBuilder.prototype = Object.create(Plugin.prototype);
+I18NAssetBuilder.constructor = I18NAssetBuilder;
 
-function I18nAssetBuilder(inputNode, options) {
+function I18NAssetBuilder(inputNodes, options) {
   options = options || {};
-  inputNode = new I18nAssetMerger(inputNode, options);
-  Filter.call(this, inputNode, {
+  Plugin.call(this, [inputNodes], {
     annotation: options.annotation
   });
-  this.outputBasePath = options.outputPath;
+  this.options = options;
 }
 
-I18nAssetBuilder.prototype.extensions = ['properties'];
-I18nAssetBuilder.prototype.targetExtension = 'js';
+I18NAssetBuilder.prototype.build = function() {
+  var outputPath = path.join(this.outputPath,  this.options.outputPath);
+  var inputPath = this.inputPaths[0];
 
-/*
-  Change oputput path to /assets/i18n - need to make this use options.outputPath
-  and should not use getDestFilePath
-*/
-// I18nAssetBuilder.prototype.getDestFilePath = function(relativePath) {
-//   var newRelativePath = Filter.prototype.getDestFilePath.call(this, relativePath);
-//   return this.outputBasePath + '/' + newRelativePath;
-// };
+  var defaultLocaleTranslations = PropertiesParser.parse(fs.readFileSync(path.join(this.inputPaths[0], 'MessageResources_en.properties')));
 
-I18nAssetBuilder.prototype.processString = function(content, relativePath) {
-  return 'Ember.STRINGS = '+ JSON.stringify(PropertiesParser.parse(content));
+  mkrip.sync(outputPath);
+
+  fs.readdirSync(inputPath).forEach(function(file) {
+    var fileName = path.basename(file,'.properties');
+    var translations = PropertiesParser.parse(fs.readFileSync(path.join(inputPath, file)));
+    translations = merge(defaultLocaleTranslations, translations);
+    fs.writeFileSync(path.join(outputPath, fileName + '.js') , 'Ember.STRINGS = ' + JSON.stringify(translations));
+  });
 };
 
-module.exports = I18nAssetBuilder;
+module.exports = I18NAssetBuilder;

--- a/lib/i18n-asset-merger.js
+++ b/lib/i18n-asset-merger.js
@@ -11,7 +11,7 @@ function I18nAssetMerger(inputNode, options) {
   directories.forEach(function(directory) {
     var fileName = '/MessageResources_' + directory + '.properties';
     var concatenatedDirectoryProperties = concat(inputNode + '/' + directory, {
-      outputFile: options.outputPath +  fileName,
+      outputFile: fileName,
       inputFiles: ['*.properties']
     });
     concatenatedProperties.push(concatenatedDirectoryProperties);
@@ -19,8 +19,7 @@ function I18nAssetMerger(inputNode, options) {
 
   //Get the seperate properties files in the parent directory and convert them to js file as such.
   var otherPropertiesFiles = funnel(inputNode, {
-    include: ['*.properties'],
-    destDir: options.outputPath
+    include: ['*.properties']
   });
 
   concatenatedProperties.push(otherPropertiesFiles);

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
   ],
   "dependencies": {
     "broccoli-concat": "^2.2.0",
-    "broccoli-filter": "^1.2.3",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
+    "broccoli-plugin": "^1.2.1",
     "ember-cli-babel": "^5.1.6",
+    "lodash.merge": "^4.4.0",
+    "mkdirp": "^0.5.1",
     "properties-parser": "^0.3.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Uses the translations in the default locale and merges it with
translations in other locales.

Other changes:
- Replaces base broccoli-filter with broccoli-plugin as base class
- Make I18NAssetBuilder take input tree after formatting from I18NAssetMerger

TODOs
- Allow default locale to be passed as option(now en)
- Channelise output file prefix `MessageResources_` and allow to be changed via options
