### PR TITLE
Adds encoding property to file IO calls

### DIFF
--- a/lib/i18n-asset-builder.js
+++ b/lib/i18n-asset-builder.js
@@ -24,11 +24,11 @@ I18NAssetBuilder.prototype.build = function() {
 
   mkrip.sync(outputPath);
 
-  fs.readdirSync(inputPath).forEach(function(file) {
+  fs.readdirSync(inputPath, { encoding: 'utf8' }).forEach(function(file) {
     var fileName = path.basename(file,'.properties');
     var translations = PropertiesParser.parse(fs.readFileSync(path.join(inputPath, file)));
     translations = merge(defaultLocaleTranslations, translations);
-    fs.writeFileSync(path.join(outputPath, fileName + '.js') , 'Ember.STRINGS = ' + JSON.stringify(translations));
+    fs.writeFileSync(path.join(outputPath, fileName + '.js'), 'Ember.STRINGS = ' + JSON.stringify(translations), { encoding: 'utf8' });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bundle-i18n",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
According to the [documentation](https://nodejs.org/api/fs.html#fs_fs_readfilesync_file_options) not return type is a string is encoding is specified, else it is a buffer.
