### PR TITLE
Bugfix merge translations

### DIFF
--- a/lib/i18n-asset-builder.js
+++ b/lib/i18n-asset-builder.js
@@ -30,7 +30,7 @@ I18NAssetBuilder.prototype.build = function() {
     var fileName = outputFilePrefix + path.basename(file, '.properties');
     var translations = parsePropertiesFile(path.join(inputPath, file));
 
-    translations = merge(defaultLocaleTranslations, translations);
+    translations = merge({}, defaultLocaleTranslations, translations);
 
     var outputString = 'Ember.STRINGS = ' + JSON.stringify(translations);
     var outputFileName = path.join(outputPath, fileName + '.js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bundle-i18n",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Merging translations when a specific language file is empty will result in the previous translated language’s content - issue fixed.