### PR TITLE
Use broccoli-caching-writer to rebuild only on *properties file changes

### DIFF
--- a/lib/i18n-asset-builder.js
+++ b/lib/i18n-asset-builder.js
@@ -1,4 +1,4 @@
-var Plugin = require('broccoli-plugin');
+var Plugin = require('broccoli-caching-writer');
 var fs = require('fs');
 var PropertiesParser = require('properties-parser');
 var mkrip = require('mkdirp');
@@ -10,6 +10,7 @@ I18NAssetBuilder.constructor = I18NAssetBuilder;
 
 function I18NAssetBuilder(inputNodes, options) {
   options = options || {};
+  options.cacheInclude = [/.properties$/];
   Plugin.call(this, [inputNodes], {
     annotation: options.annotation
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bundle-i18n",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -43,10 +43,10 @@
     "ember-addon"
   ],
   "dependencies": {
+    "broccoli-caching-writer": "^3.0.3",
     "broccoli-concat": "^2.3.8",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "broccoli-plugin": "^1.2.1",
     "ember-cli-babel": "^5.1.6",
     "lodash.merge": "^4.4.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Currently, ember-bundle-i18n process the i18n files on every rebuild even if the properties files themselves haven't changed.

By using broccoli-caching-writer, this will happen only when the properties files are changed resulting in reduced rebuild times.